### PR TITLE
Final iteration of cx bid adapter before PR

### DIFF
--- a/modules/catapaultXBidAdapter.md
+++ b/modules/catapaultXBidAdapter.md
@@ -1,0 +1,34 @@
+# Overview
+
+```
+Module Name: CatapultX Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: mannese@catapultx.com
+```
+
+# Description
+
+Module that connects to CatapultX monetize api
+Currently supports Banner format
+This supports: GDPR ConsentManagement module, US Privacy ConsentManagement module, DNT, coppa
+
+# Test Parameters
+
+```
+    var adUnits = [{
+        code: 'target-div-01',
+        mediaTypes: {
+            banner: {
+                sizes: [[300, 250]], // banner size
+            }
+        },
+        bids: [{
+            bidder: "catapultx",
+            params: {
+                groupId: 'ABC123', //required parameter
+                qxData: {}, //internal for enriched bidding from catapultx onstream integration
+                apiUrl: 'cpm.api.com', //internal for testing only
+            }
+        }]
+    }];
+```

--- a/modules/catapultxBidAdapter.js
+++ b/modules/catapultxBidAdapter.js
@@ -50,7 +50,7 @@ export const spec = {
    */
   interpretResponse: function (serverResponse) {
     let response = serverResponse.body;
-    if (!response.seatbid) {
+    if (!response.seatbid || !response?.seatbid[0]) {
       return [];
     }
     let rtbBids = response.seatbid
@@ -142,11 +142,8 @@ function buildImp(bidRequest, secure) {
     format: sizes.map(wh => parseGPTSingleSizeArrayToRtbSize(wh)),
     topframe: 0
   };
-  let floor = getBidFloor(bidRequest, BANNER, sizes);
-  if (floor) {
-    imp.bidfloor = floor;
-  }
-  if (bidRequest.ortb2Imp !== undefined && typeof bidRequest.ortb2Imp.ext === 'object') {
+  imp.bidfloor = getBidFloor(bidRequest, BANNER, sizes) || 0;
+  if (bidRequest.ortb2Imp?.ext) {
     imp.ext = bidRequest.ortb2Imp.ext;
   }
   return imp;

--- a/modules/catapultxBidAdapter.js
+++ b/modules/catapultxBidAdapter.js
@@ -28,7 +28,7 @@ export const spec = {
    * @returns {ServerRequest[]}
    */
   buildRequests: function (bidRequests, bidderRequest) {
-    let secure = (bidderRequest.refererInfo && bidderRequest.refererInfo.referer.indexOf('https:') === 0) ? 1 : 0;
+    let secure = bidderRequest?.refererInfo?.page.indexOf('https:') === 0 ? 1 : 0;
     let imps = bidRequests.map(bidRequest => buildImp(bidRequest, secure));
     let requests = [];
     let qxData = bidRequests[0].params?.qxData;

--- a/modules/catapultxBidAdapter.js
+++ b/modules/catapultxBidAdapter.js
@@ -1,0 +1,162 @@
+import {
+  isArray, getAdUnitSizes, parseGPTSingleSizeArrayToRtbSize, getDNT
+} from '../src/utils.js';
+import {BANNER} from '../src/mediaTypes.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {config} from '../src/config.js';
+
+const BIDDER_CODE = 'catapultx';
+const DEFAULT_API_URL = 'https://dev-demand.catapultx.com';
+
+export const spec = {
+  code: BIDDER_CODE,
+  /**
+   * Verifies required params to determine given bid request is valid.
+   * @param {BidRequest} bidRequest The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bidRequest) {
+    return 'params' in bidRequest &&
+      'groupId' in bidRequest.params &&
+      bidRequest.params.groupId != '' && 'banner' in bidRequest.mediaTypes;
+  },
+  /**
+   * build a valid request to be handled by catapultx demand api
+   * @return Array Info describing the request to the server.
+   * @param {BidRequest[]} bidRequests
+   * @param {BidderRequest} bidderRequest
+   * @returns {ServerRequest[]}
+   */
+  buildRequests: function (bidRequests, bidderRequest) {
+    let secure = (bidderRequest.refererInfo && bidderRequest.refererInfo.referer.indexOf('https:') === 0) ? 1 : 0;
+    let imps = bidRequests.map(bidRequest => buildImp(bidRequest, secure));
+    let requests = [];
+    let qxData = bidRequests[0].params.qxData !== undefined ? bidRequests[0].params.qxData : null;
+    let apiUrl = bidRequests[0].params.apiUrl !== undefined ? bidRequests[0].params.apiUrl : DEFAULT_API_URL;
+    const request = buildMonetizeRequest(imps, bidderRequest, qxData);
+    requests.push({
+      method: 'POST',
+      url: `${apiUrl}/api/v1/monetize/resources/prebid/${bidRequests[0].params.groupId}`,
+      data: request,
+      options: {withCredentials: false}
+    });
+    return requests;
+  },
+
+  /**
+   * Parse response from catapultx demand api
+   * @param {ServerResponse} serverResponse
+   * @returns {Bid[]}
+   */
+  interpretResponse: function (serverResponse) {
+    let response = serverResponse.body;
+    if (!response.seatbid) {
+      return [];
+    }
+    let rtbBids = response.seatbid
+      .map(seatbid => seatbid.bid)
+      .reduce((a, b) => a.concat(b), []);
+
+    return rtbBids.map(rtbBid => {
+      let prBid = {
+        requestId: rtbBid.impid,
+        cpm: rtbBid.price,
+        creativeId: rtbBid.crid,
+        currency: response.cur || 'USD',
+        ttl: 360,
+        netRevenue: true,
+        meta: {}
+      };
+      prBid.mediaType = BANNER;
+      prBid.width = rtbBid.w;
+      prBid.height = rtbBid.h;
+      prBid.ad = rtbBid.adm;
+      if (isArray(rtbBid.adomain)) {
+        prBid.meta.advertiserDomains = rtbBid.adomain;
+      }
+      if (isArray(rtbBid.cat)) {
+        prBid.meta.primaryCatId = rtbBid.cat[0];
+        if (rtbBid.cat.length > 1) {
+          prBid.meta.secondaryCatIds = rtbBid.cat.slice(1);
+        }
+      }
+      return prBid;
+    });
+  },
+
+};
+
+registerBidder(spec);
+
+/**
+ * builds PrebidRequest object for catapultx monetize/prebid endpoint
+ * @returns {String}
+ */
+function buildMonetizeRequest(imps, bidderRequest, qxData) {
+  let {gdprConsent, auctionId, timeout, uspConsent} = bidderRequest;
+  let coppa = config.getConfig('coppa');
+  let req = {
+    'id': auctionId,
+    'imp': imps,
+    'tmax': timeout,
+    'coppa': 0
+  };
+  if (getDNT()) {
+    req.dnt = 1;
+  }
+  if (coppa !== undefined && coppa === true) {
+    req.coppa = 1;
+  }
+  if (qxData) {
+    req.qxData = qxData;
+  }
+  if (gdprConsent) {
+    if (gdprConsent.gdprApplies !== undefined) {
+      req.GDPRApplies = gdprConsent.gdprApplies ? 1 : 0;
+    }
+    if (gdprConsent.consentString !== undefined) {
+      req.TCString = gdprConsent.consentString
+    }
+  }
+  if (uspConsent) {
+    req.USPString = uspConsent;
+  }
+  return req;
+}
+
+/**
+ * generates rtb Imp object from bidrequest
+ * @param {BidRequest} bidRequest
+ * @param {Number} secure
+ * @returns Imp object
+ */
+function buildImp(bidRequest, secure) {
+  const imp = {
+    'id': bidRequest.bidId,
+    'tagid': bidRequest.adUnitCode,
+    'secure': secure
+  };
+  var sizes = [];
+  sizes = getAdUnitSizes(bidRequest);
+  imp.banner = {
+    format: sizes.map(wh => parseGPTSingleSizeArrayToRtbSize(wh)),
+    topframe: 0
+  };
+  let floor = getBidFloor(bidRequest, BANNER, sizes);
+  if (floor) {
+    imp.bidfloor = floor;
+  }
+  return imp;
+}
+
+function getBidFloor(bid, mediaType, sizes) {
+  var floor;
+  var size = sizes.length === 1 ? sizes[0] : '*';
+  if (typeof bid.getFloor === 'function') {
+    const floorInfo = bid.getFloor({currency: 'USD', mediaType, size});
+    if (typeof floorInfo === 'object' && floorInfo.currency === 'USD' && !isNaN(parseFloat(floorInfo.floor))) {
+      floor = parseFloat(floorInfo.floor);
+    }
+  }
+  return floor;
+}

--- a/modules/catapultxBidAdapter.js
+++ b/modules/catapultxBidAdapter.js
@@ -146,6 +146,9 @@ function buildImp(bidRequest, secure) {
   if (floor) {
     imp.bidfloor = floor;
   }
+  if (bidRequest.ortb2Imp !== undefined && typeof bidRequest.ortb2Imp.ext === 'object') {
+    imp.ext = bidRequest.ortb2Imp.ext;
+  }
   return imp;
 }
 

--- a/modules/catapultxBidAdapter.js
+++ b/modules/catapultxBidAdapter.js
@@ -31,8 +31,8 @@ export const spec = {
     let secure = (bidderRequest.refererInfo && bidderRequest.refererInfo.referer.indexOf('https:') === 0) ? 1 : 0;
     let imps = bidRequests.map(bidRequest => buildImp(bidRequest, secure));
     let requests = [];
-    let qxData = bidRequests[0].params.qxData !== undefined ? bidRequests[0].params.qxData : null;
-    let apiUrl = bidRequests[0].params.apiUrl !== undefined ? bidRequests[0].params.apiUrl : DEFAULT_API_URL;
+    let qxData = bidRequests[0].params?.qxData;
+    let apiUrl = bidRequests[0].params?.apiUrl || DEFAULT_API_URL;
     const request = buildMonetizeRequest(imps, bidderRequest, qxData);
     requests.push({
       method: 'POST',

--- a/modules/catapultxBidAdapter.js
+++ b/modules/catapultxBidAdapter.js
@@ -6,7 +6,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
 
 const BIDDER_CODE = 'catapultx';
-const DEFAULT_API_URL = 'https://dev-demand.catapultx.com';
+const DEFAULT_API_URL = 'https://demand.catapultx.com';
 
 export const spec = {
   code: BIDDER_CODE,

--- a/modules/catapultxBidAdapter.js
+++ b/modules/catapultxBidAdapter.js
@@ -37,8 +37,8 @@ export const spec = {
     requests.push({
       method: 'POST',
       url: `${apiUrl}/api/v1/monetize/resources/prebid/${bidRequests[0].params.groupId}`,
-      data: request,
-      options: {withCredentials: false}
+      data: JSON.stringify(request),
+      options: {withCredentials: false, contentType: 'application/json'}
     });
     return requests;
   },
@@ -93,13 +93,14 @@ registerBidder(spec);
  * @returns {String}
  */
 function buildMonetizeRequest(imps, bidderRequest, qxData) {
-  let {gdprConsent, auctionId, timeout, uspConsent} = bidderRequest;
+  let {gdprConsent, auctionId, timeout, uspConsent, ortb2} = bidderRequest;
   let coppa = config.getConfig('coppa');
   let req = {
     'id': auctionId,
     'imp': imps,
     'tmax': timeout,
-    'coppa': 0
+    'coppa': 0,
+    'content': null
   };
   if (getDNT()) {
     req.dnt = 1;
@@ -120,6 +121,10 @@ function buildMonetizeRequest(imps, bidderRequest, qxData) {
   }
   if (uspConsent) {
     req.USPString = uspConsent;
+  }
+  //this will need to be santized on either end
+  if (ortb2?.site?.content) {
+    req.content = ortb2?.site?.content
   }
   return req;
 }

--- a/modules/catapultxBidAdapter.md
+++ b/modules/catapultxBidAdapter.md
@@ -26,8 +26,6 @@ This supports: GDPR ConsentManagement module, US Privacy ConsentManagement modul
             bidder: "catapultx",
             params: {
                 groupId: 'ABC123', //required parameter
-                qxData: {}, //internal for enriched bidding from catapultx onstream integration
-                apiUrl: 'cpm.api.com', //internal for testing only
             }
         }]
     }];

--- a/test/spec/modules/catapultxBidAdapter_spec.js
+++ b/test/spec/modules/catapultxBidAdapter_spec.js
@@ -309,7 +309,7 @@ describe('CatapultX adapter', function () {
   describe('interpreting group id and apiUrl', function () {
     it('should default to default apiUrl', function () {
       let requests = buildRequest([no_apiUrl_has_qxData_bid]);
-      expect(requests[0].url).to.have.string('https://dev-demand.catapultx.com');
+      expect(requests[0].url).to.have.string('https://demand.catapultx.com');
     });
 
     it('should set apiUrl if sent in params', function () {

--- a/test/spec/modules/catapultxBidAdapter_spec.js
+++ b/test/spec/modules/catapultxBidAdapter_spec.js
@@ -1,0 +1,349 @@
+import {expect} from 'chai';
+import {spec} from 'modules/catapultxBidAdapter';
+import * as utils from 'src/utils';
+import {BANNER} from 'src/mediaTypes';
+import {config} from 'src/config';
+
+describe('CatapultX adapter', function () {
+  const sample_qxData = {
+      groupId: 'internal',
+      testKey: 'Key_1'
+    },
+    no_params_bid = {
+      bidder: 'catapultx',
+      bidId: 'testBid1',
+      bidderRequestId: 'testRequest1',
+      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a'
+    },
+    no_groupId_bid = {
+      bidder: 'catapultx',
+      params: {},
+      adUnitCode: 'adUnitTestCode',
+      bidId: 'testBid1',
+      bidderRequestId: 'testRequest1',
+      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250]]
+        }
+      }
+    },
+    empty_groupId_bid = {
+      bidder: 'catapultx',
+      params: {groupId: ''},
+      adUnitCode: 'adUnitTestCode',
+      bidId: 'testBid1',
+      bidderRequestId: 'testRequest1',
+      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250]]
+        }
+      }
+    },
+    native_bid = {
+      bidder: 'catapultx',
+      params: {groupId: 'internal'},
+      adUnitCode: 'adUnitTestCode',
+      bidId: 'testBid1',
+      bidderRequestId: 'testRequest1',
+      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
+      mediaTypes: {
+        native: {}
+      }
+    },
+    no_optional_params_valid_bid = {
+      bidder: 'catapultx',
+      params: {groupId: 'internal'},
+      adUnitCode: 'adUnitTestCode',
+      bidId: 'testBid1',
+      bidderRequestId: 'testRequest1',
+      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250]]
+        }
+      }
+    },
+    no_qxdata_has_apiurl_bid = {
+      bidder: 'catapultx',
+      params: {groupId: 'internal', apiUrl: 'example.com'},
+      adUnitCode: 'adUnitTestCode',
+      bidId: 'testBid1',
+      bidderRequestId: 'testRequest1',
+      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250]]
+        }
+      }
+    },
+    no_apiUrl_has_qxData_bid = {
+      bidder: 'catapultx',
+      params: {groupId: 'internal', qxData: {}},
+      adUnitCode: 'adUnitTestCode',
+      bidId: 'testBid2',
+      bidderRequestId: 'testRequest1',
+      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250]]
+        }
+      }
+    },
+    enriched_overlay_request = {
+      bidder: 'catapultx',
+      params: {groupId: 'internal', qxData: sample_qxData, apiUrl: 'example.com'},
+      adUnitCode: 'adUnitTestCode',
+      bidId: 'testBid3',
+      bidderRequestId: 'testRequest1',
+      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250]]
+        }
+      }
+    },
+    bid_response = {
+      'id': '26afda50-b43b-49c5-8b27-a25149167283',
+      'seatbid': [
+        {
+          'bid': [
+            {
+              'id': 'id123',
+              'impid': 'testBid3',
+              'price': 2,
+              'adid': '80152',
+              'nurl': 'https://demand.example.com/win?i=id123',
+              'adm': '<!-- cx bidadapter test -->',
+              'adomain': [
+                'example.com'
+              ],
+              'iurl': 'https://demand.example.com/yetfs.png',
+              'cid': '1234',
+              'crid': 'crid123',
+              'cat': [
+                'IAB1',
+                'IAB2',
+                'IAB123'
+              ],
+              'w': 728,
+              'h': 90
+            }
+          ],
+          'seat': '123555'
+        }
+      ],
+      'bidid': 'bidid',
+      'cur': 'USD',
+      'nbr': 0
+    }
+
+  var sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    config.resetConfig();
+  });
+
+  function buildBidderRequest(url = 'https://example.com/index.html', params = {}) {
+    return Object.assign({}, params, {refererInfo: {referer: url, reachedTop: true}, timeout: 3000, bidderCode: 'catapultx'});
+  }
+  const DEFAULT_BIDDER_REQUEST = buildBidderRequest();
+
+  function buildRequest(bidRequests, bidderRequest = DEFAULT_BIDDER_REQUEST, dnt = true) {
+    let dntmock = sandbox.stub(utils, 'getDNT').callsFake(() => dnt);
+    bidderRequest.bids = bidRequests;
+    let requests = spec.buildRequests(bidRequests, bidderRequest);
+    dntmock.restore();
+    return requests
+  }
+
+  describe('bid request validation', function () {
+    it('fails validation for bid with no params object', function () {
+      expect(spec.isBidRequestValid(no_params_bid)).to.be.equal(false);
+    });
+
+    it('fails validation for bid with no groupId', function () {
+      expect(spec.isBidRequestValid(no_groupId_bid)).to.be.equal(false);
+    });
+
+    it('fails validation for bid wth empty groupId', function () {
+      expect(spec.isBidRequestValid(empty_groupId_bid)).to.be.equal(false);
+    });
+
+    it('will not validate non banner bids', function () {
+      expect(spec.isBidRequestValid(native_bid)).to.be.equal(false);
+    });
+
+    it('will validate complete banner requests with no optional parameters', () => {
+      expect(spec.isBidRequestValid(no_optional_params_valid_bid)).to.be.equal(true);
+    });
+
+    it('will validate requests that use optional parameters', () => {
+      expect(spec.isBidRequestValid(no_qxdata_has_apiurl_bid)).to.be.equal(true);
+      expect(spec.isBidRequestValid(no_apiUrl_has_qxData_bid)).to.be.equal(true);
+      expect(spec.isBidRequestValid(enriched_overlay_request)).to.be.equal(true);
+    })
+  });
+
+  describe('monetize request generation', function () {
+    let monetizeRequest;
+
+    before(function () {
+      let requests = buildRequest([no_qxdata_has_apiurl_bid, enriched_overlay_request]);
+      monetizeRequest = requests[0].data;
+    });
+
+    it('should have banner object', function () {
+      expect(monetizeRequest.imp[0]).to.have.property('banner');
+    });
+
+    it('should have corresponding bidId', function () {
+      expect(monetizeRequest.imp[0]).to.have.property('id');
+      expect(monetizeRequest.imp[0].id).to.be.eql('testBid1');
+      expect(monetizeRequest.imp[1]).to.have.property('id');
+      expect(monetizeRequest.imp[1].id).to.be.eql('testBid3');
+    });
+
+    it('should have format object', function () {
+      expect(monetizeRequest.imp[0].banner).to.have.property('format');
+      expect(monetizeRequest.imp[0].banner.format).to.be.eql([{w: 300, h: 250}]);
+    });
+
+    it('should evaluate and send secure value', function () {
+      expect(monetizeRequest.imp[0]).to.have.property('secure', 1);
+    });
+
+    it('should properly identify non https and send 0 for secure', function () {
+      let httpRequests = buildRequest([enriched_overlay_request], buildBidderRequest('http://example.com/index.html'));
+      let notSecure = httpRequests[0].data;
+      expect(notSecure.imp[0]).to.have.property('secure', 0);
+    });
+
+    it('should have tagid', function () {
+      expect(monetizeRequest.imp[0]).to.have.property('tagid', 'adUnitTestCode');
+    });
+
+    it('should have tmax', function () {
+      expect(monetizeRequest.tmax).to.be.equal(3000);
+    });
+
+    it('will not add qxData object if it does not exist', function () {
+      expect(monetizeRequest).to.not.have.property('qxData');
+    });
+
+    it('will send qxData object when applicable', function () {
+      let overlay_mock = buildRequest([enriched_overlay_request]);
+      const enrichedRequest = overlay_mock[0].data;
+      expect(enrichedRequest.qxData).to.be.eql(sample_qxData);
+    });
+
+    it('will not add consent information if it does not exist', function () {
+      expect(monetizeRequest).to.not.have.property('GDPRApplies');
+      expect(monetizeRequest).to.not.have.property('TCString');
+      expect(monetizeRequest).to.not.have.property('USPString');
+    });
+
+    it('should contain gdpr-related information if consent is configured', function () {
+      let requests = buildRequest([enriched_overlay_request],
+        buildBidderRequest('https://example.com/index.html',
+          {gdprConsent: {gdprApplies: true, consentString: 'tcStringValue', vendorData: {}}, uspConsent: '1YNN'}));
+      monetizeRequest = requests[0].data;
+      expect(monetizeRequest).to.have.property('GDPRApplies');
+      expect(monetizeRequest.GDPRApplies).to.be.eql(1);
+      expect(monetizeRequest).to.have.property('TCString');
+      expect(monetizeRequest.TCString).to.be.eql('tcStringValue');
+      expect(monetizeRequest).to.have.property('USPString');
+      expect(monetizeRequest.USPString).to.be.eql('1YNN');
+    });
+
+    it('should send 0 value for coppa when not true', function () {
+      expect(monetizeRequest.coppa).to.be.eql(0);
+    });
+
+    it('should contain coppa if configured', function () {
+      config.setConfig({coppa: true});
+      let requests = buildRequest([no_qxdata_has_apiurl_bid]);
+      monetizeRequest = requests[0].data;
+      expect(monetizeRequest).to.have.property('coppa');
+      expect(monetizeRequest.coppa).to.be.eql(1);
+    });
+
+    it('should only send configured values for consent information', function () {
+      let requests = buildRequest([enriched_overlay_request], buildBidderRequest('https://example.com/index.html', {gdprConsent: {gdprApplies: false}}));
+      monetizeRequest = requests[0].data;
+      expect(monetizeRequest).to.have.property('GDPRApplies')
+      expect(monetizeRequest.GDPRApplies).to.be.eql(0);
+      expect(monetizeRequest).to.not.have.property('TCString');
+      expect(monetizeRequest).to.not.have.property('USPString');
+    });
+
+    it('should not include dnt if not applicable', function () {
+      let requests = buildRequest([enriched_overlay_request], DEFAULT_BIDDER_REQUEST, false);
+      expect(requests[0].data).to.not.have.property('dnt');
+    });
+
+    it('should set dnt if applicable', function () {
+      expect(monetizeRequest).to.have.property('dnt');
+      expect(monetizeRequest.dnt).to.be.eql(1);
+    });
+
+    it('should set bidfloor if configured', function() {
+      let bid = Object.assign({}, enriched_overlay_request);
+      bid.getFloor = function() {
+        return {
+          currency: 'USD',
+          floor: 0.145
+        }
+      };
+      let requests = buildRequest([bid]);
+      expect(requests[0].data.imp[0]).to.have.property('bidfloor', 0.145);
+    });
+  });
+
+  describe('interpreting group id and apiUrl', function () {
+    it('should default to default apiUrl', function () {
+      let requests = buildRequest([no_apiUrl_has_qxData_bid]);
+      expect(requests[0].url).to.have.string('https://dev-demand.catapultx.com');
+    });
+
+    it('should set apiUrl if sent in params', function () {
+      let requests = buildRequest([enriched_overlay_request]);
+      expect(requests[0].url).to.have.string('example.com');
+      expect(requests[0].url.split('/')[0]).to.be.eql('example.com');
+    });
+
+    it('should set groupId from params', function () {
+      let requests = buildRequest([enriched_overlay_request]);
+      expect(requests[0].url).to.have.string('internal');
+      expect(requests[0].url.split('/').pop()).to.be.eql('internal');
+    });
+  });
+
+  describe('interprets responses', function () {
+    it('should interpret banner rtb response', function () {
+      let resp = spec.interpretResponse({body: bid_response})[0];
+      expect(resp).to.have.property('requestId', 'testBid3');
+      expect(resp).to.have.property('cpm', 2);
+      expect(resp).to.have.property('width', 728);
+      expect(resp).to.have.property('height', 90);
+      expect(resp).to.have.property('creativeId', 'crid123');
+      expect(resp).to.have.property('currency');
+      expect(resp).to.have.property('ttl');
+      expect(resp).to.have.property('mediaType', BANNER);
+      expect(resp).to.have.property('ad');
+      expect(resp.ad).to.have.string('<!-- cx bidadapter test -->');
+      expect(resp).to.have.property('meta');
+      expect(resp).to.have.property('netRevenue');
+      expect(resp.netRevenue).to.be.true;
+      expect(resp.meta.advertiserDomains).to.be.eql(['example.com']);
+      expect(resp.meta.primaryCatId).to.be.eql('IAB1');
+      expect(resp.meta.secondaryCatIds).to.be.eql(['IAB2', 'IAB123']);
+    });
+  });
+});

--- a/test/spec/modules/catapultxBidAdapter_spec.js
+++ b/test/spec/modules/catapultxBidAdapter_spec.js
@@ -9,22 +9,22 @@ describe('CatapultX adapter', () => {
   let bidResponse;
 
   const sample_qxData = {
-      groupId: 'internal',
-      testKey: 'Key_1'
-    }
+    groupId: 'internal',
+    testKey: 'Key_1'
+  }
 
   const ortb2Data = {
-      site: {
-        content: {
-          id: '123456',
-          episode: 15,
-          title: 'test episode',
-          series: 'test show',
-          season: '1',
-          url: 'https://example.com/file.mp4'
-        }
+    site: {
+      content: {
+        id: '123456',
+        episode: 15,
+        title: 'test episode',
+        series: 'test show',
+        season: '1',
+        url: 'https://example.com/file.mp4'
       }
     }
+  }
 
   const exampleUrl = 'https://example.com/index.html';
 
@@ -205,7 +205,7 @@ describe('CatapultX adapter', () => {
 
     it('should default bidfloor 0 if getFloor returns invalid response', () => {
       bidRequest.getFloor = () => {
-        return "string";
+        return 'string';
       };
       const imp = data(buildRequest([bidRequest])).imp[0];
       expect(imp).to.have.property('bidfloor', 0);
@@ -345,7 +345,7 @@ describe('CatapultX adapter', () => {
     });
 
     it('should return empty array for missing seatbid array', () => {
-      delete bidResponse.seatbid 
+      delete bidResponse.seatbid
       const resp = spec.interpretResponse({body: bidResponse});
       expect(resp).to.be.eql([]);
     });
@@ -358,7 +358,7 @@ describe('CatapultX adapter', () => {
     });
 
     it('should not add invalid adomain', () => {
-      bidResponse.seatbid[0].bid[0].adomain = "string"
+      bidResponse.seatbid[0].bid[0].adomain = 'string'
       const resp = spec.interpretResponse({body: bidResponse})[0];
       expect(resp?.meta?.advertiserDomains).to.be.undefined;
     });

--- a/test/spec/modules/catapultxBidAdapter_spec.js
+++ b/test/spec/modules/catapultxBidAdapter_spec.js
@@ -220,7 +220,7 @@ describe('CatapultX adapter', function () {
   });
 
   function buildBidderRequest(url = 'https://example.com/index.html', params = {}) {
-    return Object.assign({}, params, {refererInfo: {referer: url, reachedTop: true}, timeout: 3000, bidderCode: 'catapultx'});
+    return Object.assign({}, params, {refererInfo: {page: url, reachedTop: true}, timeout: 3000, bidderCode: 'catapultx'});
   }
   const DEFAULT_BIDDER_REQUEST = buildBidderRequest();
 

--- a/test/spec/modules/catapultxBidAdapter_spec.js
+++ b/test/spec/modules/catapultxBidAdapter_spec.js
@@ -4,111 +4,36 @@ import * as utils from 'src/utils';
 import {BANNER} from 'src/mediaTypes';
 import {config} from 'src/config';
 
-describe('CatapultX adapter', function () {
+describe('CatapultX adapter', () => {
+  let bidRequest;
+  let bidResponse;
+
   const sample_qxData = {
       groupId: 'internal',
       testKey: 'Key_1'
-    },
-    no_params_bid = {
-      bidder: 'catapultx',
-      bidId: 'testBid1',
-      bidderRequestId: 'testRequest1',
-      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a'
-    },
-    no_groupId_bid = {
-      bidder: 'catapultx',
-      params: {},
-      adUnitCode: 'adUnitTestCode',
-      bidId: 'testBid1',
-      bidderRequestId: 'testRequest1',
-      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
-      mediaTypes: {
-        banner: {
-          sizes: [[300, 250]]
+    }
+
+  const ortb2Data = {
+      site: {
+        content: {
+          id: '123456',
+          episode: 15,
+          title: 'test episode',
+          series: 'test show',
+          season: '1',
+          url: 'https://example.com/file.mp4'
         }
       }
-    },
-    empty_groupId_bid = {
+    }
+
+  const exampleUrl = 'https://example.com/index.html';
+
+  beforeEach(() => {
+    bidRequest = {
       bidder: 'catapultx',
-      params: {groupId: ''},
+      params: {groupId: 'internal', qxData: sample_qxData, apiUrl: 'https://example.com'},
       adUnitCode: 'adUnitTestCode',
-      bidId: 'testBid1',
-      bidderRequestId: 'testRequest1',
-      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
-      mediaTypes: {
-        banner: {
-          sizes: [[300, 250]]
-        }
-      }
-    },
-    native_bid = {
-      bidder: 'catapultx',
-      params: {groupId: 'internal'},
-      adUnitCode: 'adUnitTestCode',
-      bidId: 'testBid1',
-      bidderRequestId: 'testRequest1',
-      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
-      mediaTypes: {
-        native: {}
-      }
-    },
-    no_optional_params_valid_bid = {
-      bidder: 'catapultx',
-      params: {groupId: 'internal'},
-      adUnitCode: 'adUnitTestCode',
-      bidId: 'testBid1',
-      bidderRequestId: 'testRequest1',
-      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
-      mediaTypes: {
-        banner: {
-          sizes: [[300, 250]]
-        }
-      }
-    },
-    no_qxdata_has_apiurl_bid = {
-      bidder: 'catapultx',
-      params: {groupId: 'internal', apiUrl: 'example.com'},
-      adUnitCode: 'adUnitTestCode',
-      bidId: 'testBid1',
-      bidderRequestId: 'testRequest1',
-      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
-      mediaTypes: {
-        banner: {
-          sizes: [[300, 250]]
-        }
-      }
-    },
-    no_apiUrl_has_qxData_bid = {
-      bidder: 'catapultx',
-      params: {groupId: 'internal', qxData: {}},
-      adUnitCode: 'adUnitTestCode',
-      bidId: 'testBid2',
-      bidderRequestId: 'testRequest1',
-      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
-      mediaTypes: {
-        banner: {
-          sizes: [[300, 250]]
-        }
-      }
-    },
-    non_enriched_bid_multiple_sizes = {
-      bidder: 'catapultx',
-      params: {groupId: 'internal'},
-      adUnitCode: 'adUnitTestCode',
-      bidId: 'testBid2',
-      bidderRequestId: 'testRequest1',
-      auctionId: 'eb66abdc-bdb4-4dfd-a5af-9a9ec70dc98a',
-      mediaTypes: {
-        banner: {
-          sizes: [[300, 250], [900, 78]]
-        }
-      }
-    },
-    enriched_overlay_request = {
-      bidder: 'catapultx',
-      params: {groupId: 'internal', qxData: sample_qxData, apiUrl: 'example.com'},
-      adUnitCode: 'adUnitTestCode',
-      bidId: 'testBid3',
+      bidId: 'bidRequestId',
       bidderRequestId: 'testRequest1',
       ortb2Imp: {
         ext: {
@@ -126,268 +51,242 @@ describe('CatapultX adapter', function () {
           sizes: [[300, 250]]
         }
       }
-    },
-    no_seatbid_response = {
-      'id': '26afda50-b43b-49c5-8b27-a25149167283',
-      'seatbid': [],
-      'bidid': 'bidid',
-      'cur': 'USD',
-      'nbr': 0
-    },
-    missing_seatbid_response = {
-      'id': '26afda50-b43b-49c5-8b27-a25149167283',
-      'bidid': 'bidid',
-      'cur': 'USD',
-      'nbr': 0
-    },
-    missing_cur_bid_response = {
-      'id': '26afda50-b43b-49c5-8b27-a25149167283',
-      'seatbid': [
+    };
+    bidResponse = {
+      id: '26afda50-b43b-49c5-8b27-a25149167283',
+      seatbid: [
         {
-          'bid': [
+          bid: [
             {
-              'id': 'id123',
-              'impid': 'testBid3',
-              'price': 2,
-              'adid': '80152',
-              'nurl': 'https://demand.example.com/win?i=id123',
-              'adm': '<!-- cx bidadapter test -->',
-              'adomain': [
+              id: 'id123',
+              impid: 'testBid3',
+              price: 2,
+              adid: '80152',
+              nurl: 'https://demand.example.com/win?i=id123',
+              adm: '<!-- cx bidadapter test -->',
+              adomain: [
                 'example.com'
               ],
-              'iurl': 'https://demand.example.com/yetfs.png',
-              'cid': '1234',
-              'crid': 'crid123',
-              'cat': [
+              iurl: 'https://demand.example.com/yetfs.png',
+              cid: '1234',
+              crid: 'crid123',
+              cat: [
                 'IAB1',
                 'IAB2',
                 'IAB123'
               ],
-              'w': 728,
-              'h': 90
+              w: 728,
+              h: 90
             }
           ],
-          'seat': '123555'
+          seat: '123555'
         }
       ],
-      'bidid': 'bidid',
-      'nbr': 0
-    },
-    bid_response = {
-      'id': '26afda50-b43b-49c5-8b27-a25149167283',
-      'seatbid': [
-        {
-          'bid': [
-            {
-              'id': 'id123',
-              'impid': 'testBid3',
-              'price': 2,
-              'adid': '80152',
-              'nurl': 'https://demand.example.com/win?i=id123',
-              'adm': '<!-- cx bidadapter test -->',
-              'adomain': [
-                'example.com'
-              ],
-              'iurl': 'https://demand.example.com/yetfs.png',
-              'cid': '1234',
-              'crid': 'crid123',
-              'cat': [
-                'IAB1',
-                'IAB2',
-                'IAB123'
-              ],
-              'w': 728,
-              'h': 90
-            }
-          ],
-          'seat': '123555'
-        }
-      ],
-      'bidid': 'bidid',
-      'cur': 'testCur',
-      'nbr': 0
+      bidid: 'bidid',
+      cur: 'testCur',
+      nbr: 0
     }
-
-  var sandbox;
-
-  beforeEach(function () {
-    sandbox = sinon.sandbox.create();
   });
 
-  afterEach(function () {
-    sandbox.restore();
+  afterEach(() => {
     config.resetConfig();
   });
 
-  function buildBidderRequest(url = 'https://example.com/index.html', params = {}) {
+  const buildBidderRequest = (url = exampleUrl, params = {}) => {
     return Object.assign({}, params, {refererInfo: {page: url, reachedTop: true}, timeout: 3000, bidderCode: 'catapultx'});
   }
-  const DEFAULT_BIDDER_REQUEST = buildBidderRequest();
 
-  function buildRequest(bidRequests, bidderRequest = DEFAULT_BIDDER_REQUEST, dnt = true) {
-    let dntmock = sandbox.stub(utils, 'getDNT').callsFake(() => dnt);
+  const buildRequest = (bidRequests, bidderRequest = buildBidderRequest(), dnt = true) => {
+    let dntmock = sinon.stub(utils, 'getDNT').callsFake(() => dnt);
     bidderRequest.bids = bidRequests;
-    let requests = spec.buildRequests(bidRequests, bidderRequest);
+    let request = spec.buildRequests(bidRequests, bidderRequest);
     dntmock.restore();
-    return requests
+    return request;
   }
 
-  describe('bid request validation', function () {
-    it('fails validation for bid with no params object', function () {
-      expect(spec.isBidRequestValid(no_params_bid)).to.be.equal(false);
+  const data = (request) => {
+    return JSON.parse(request.data);
+  }
+
+  describe('bid request validation', () => {
+    it('fails validation for bid with no params object', () => {
+      delete bidRequest.params;
+      expect(spec.isBidRequestValid(bidRequest)).to.be.equal(false);
     });
 
-    it('fails validation for bid with no groupId', function () {
-      expect(spec.isBidRequestValid(no_groupId_bid)).to.be.equal(false);
+    it('fails validation for bid with no groupId', () => {
+      delete bidRequest.params.groupId;
+      expect(spec.isBidRequestValid(bidRequest)).to.be.equal(false);
     });
 
-    it('fails validation for bid wth empty groupId', function () {
-      expect(spec.isBidRequestValid(empty_groupId_bid)).to.be.equal(false);
+    it('fails validation for bid wth empty groupId', () => {
+      bidRequest.params.groupId = '';
+      expect(spec.isBidRequestValid(bidRequest)).to.be.equal(false);
     });
 
-    it('will not validate non banner bids', function () {
-      expect(spec.isBidRequestValid(native_bid)).to.be.equal(false);
+    it('will not validate non banner bids', () => {
+      bidRequest.mediaTypes = { native: {} };
+      expect(spec.isBidRequestValid(bidRequest)).to.be.equal(false);
     });
 
     it('will validate complete banner requests with no optional parameters', () => {
-      expect(spec.isBidRequestValid(no_optional_params_valid_bid)).to.be.equal(true);
-    });
-
-    it('will validate requests that use optional parameters', () => {
-      expect(spec.isBidRequestValid(no_qxdata_has_apiurl_bid)).to.be.equal(true);
-      expect(spec.isBidRequestValid(no_apiUrl_has_qxData_bid)).to.be.equal(true);
-      expect(spec.isBidRequestValid(enriched_overlay_request)).to.be.equal(true);
-    })
-  });
-
-  describe('interpreting group id and apiUrl', function () {
-    it('should default to default apiUrl', function () {
-      let requests = buildRequest([no_apiUrl_has_qxData_bid]);
-      expect(requests[0].url).to.have.string('https://demand.catapultx.com');
-    });
-
-    it('should set apiUrl if sent in params', function () {
-      let requests = buildRequest([enriched_overlay_request]);
-      expect(requests[0].url).to.have.string('example.com');
-      expect(requests[0].url.split('/')[0]).to.be.eql('example.com');
-    });
-
-    it('should set groupId from params', function () {
-      let requests = buildRequest([enriched_overlay_request]);
-      expect(requests[0].url).to.have.string('internal');
-      expect(requests[0].url.split('/').pop()).to.be.eql('internal');
+      delete bidRequest.params.apiUrl;
+      delete bidRequest.params.qxData;
+      expect(spec.isBidRequestValid(bidRequest)).to.be.equal(true);
     });
   });
 
-  describe('ortb imp generation', function () {
-    let ortbImps;
+  describe('interpreting group id and apiUrl', () => {
+    const endpointPath = '/api/v1/monetize/resources/prebid'
+    const defaultApiHost = 'https://demand.catapultx.com';
 
-    before(function () {
-      let requests = buildRequest([no_qxdata_has_apiurl_bid, enriched_overlay_request]);
-      ortbImps = requests[0].data.imp;
+    it('should default to default apiUrl', () => {
+      delete bidRequest.params.apiUrl;
+      let request = buildRequest([bidRequest]);
+      expect(request.url).to.be.eql(defaultApiHost + endpointPath);
     });
 
-    it('should have banner object', function () {
-      expect(ortbImps[0]).to.have.property('banner');
+    it('should set apiUrl if sent in params', () => {
+      let request = buildRequest([bidRequest]);
+      expect(request.url).to.be.eql(bidRequest.params.apiUrl + endpointPath);
     });
 
-    it('should have corresponding bidId', function () {
-      expect(ortbImps[0]).to.have.property('id');
-      expect(ortbImps[0].id).to.be.eql('testBid1');
-      expect(ortbImps[1]).to.have.property('id');
-      expect(ortbImps[1].id).to.be.eql('testBid3');
+    it('should set groupId from params', () => {
+      let request = buildRequest([bidRequest]);
+      expect(data(request).groupId).to.be.eql(bidRequest.params.groupId);
+    });
+  });
+
+  describe('ortb imp generation', () => {
+    let ortbImp;
+
+    beforeEach(() => {
+      ortbImp = data(buildRequest([bidRequest])).imp[0];
     });
 
-    it('should have format object', function () {
-      expect(ortbImps[0].banner).to.have.property('format');
-      expect(ortbImps[0].banner.format).to.be.eql([{w: 300, h: 250}]);
+    it('should have banner object', () => {
+      expect(ortbImp).to.have.property('banner');
     });
 
-    it('should evaluate and send secure value', function () {
-      expect(ortbImps[0]).to.have.property('secure', 1);
+    it('should create multiple imps for multiple bids', () => {
+      const bidRequest2 = Object.assign({}, bidRequest);
+      bidRequest2.bidId = 'bidRequest2Id'
+      const imps = data(buildRequest([bidRequest, bidRequest2])).imp;
+      expect(imps.length).to.eql(2);
+      expect(imps[0]).to.have.property('id');
+      expect(imps[0].id).to.eql('bidRequestId');
+      expect(imps[1]).to.have.property('id');
+      expect(imps[1].id).to.eql('bidRequest2Id');
     });
 
-    it('should properly identify non https and send 0 for secure', function () {
-      let httpRequests = buildRequest([enriched_overlay_request], buildBidderRequest('http://example.com/index.html'));
-      let notSecure = httpRequests[0].data.imp[0];
-      expect(notSecure).to.have.property('secure', 0);
+    it('should have format object', () => {
+      expect(ortbImp.banner).to.have.property('format');
+      expect(ortbImp.banner.format).to.be.eql([{w: 300, h: 250}]);
     });
 
-    it('should have tagid', function () {
-      expect(ortbImps[0]).to.have.property('tagid', 'adUnitTestCode');
+    it('should evaluate and send secure value', () => {
+      expect(ortbImp).to.have.property('secure', 1);
     });
 
-    it('should default bidfloor 0 if not configured', function() {
-      expect(ortbImps[0]).to.have.property('bidfloor', 0);
+    it('should properly identify non https and send 0 for secure', () => {
+      const nonSecureUrl = 'http://example.com/index.html';
+      const request = buildRequest([bidRequest], buildBidderRequest(nonSecureUrl));
+      const notSecureImp = data(request).imp[0];
+      expect(notSecureImp).to.have.property('secure', 0);
     });
 
-    it('should set bidfloor if configured', function() {
-      let bid = Object.assign({}, enriched_overlay_request);
-      bid.getFloor = function() {
+    it('should have tagid', () => {
+      expect(ortbImp).to.have.property('tagid', 'adUnitTestCode');
+    });
+
+    it('should default bidfloor 0 if not configured', () => {
+      expect(ortbImp).to.have.property('bidfloor', 0);
+    });
+
+    it('should default bidfloor 0 if getFloor returns invalid response', () => {
+      bidRequest.getFloor = () => {
+        return "string";
+      };
+      const imp = data(buildRequest([bidRequest])).imp[0];
+      expect(imp).to.have.property('bidfloor', 0);
+    });
+
+    it('should set bidfloor if configured', () => {
+      bidRequest.getFloor = () => {
         return {
           currency: 'USD',
           floor: 0.145
         }
       };
-      let requests = buildRequest([bid]);
-      expect(requests[0].data.imp[0]).to.have.property('bidfloor', 0.145);
+      const imp = data(buildRequest([bidRequest])).imp[0];
+      expect(imp).to.have.property('bidfloor', 0.145);
     });
 
-    it('should set bidfloor if configured on bid with multiple sizes', function() {
-      let bid = Object.assign({}, non_enriched_bid_multiple_sizes);
-      bid.getFloor = function() {
+    it('should set bidfloor if configured on bid with multiple sizes', () => {
+      bidRequest.mediaTypes.banner.sizes = [[300, 250], [900, 78]]
+      bidRequest.getFloor = () => {
         return {
           currency: 'USD',
           floor: 0.145
         }
       };
-      let requests = buildRequest([bid]);
-      expect(requests[0].data.imp[0]).to.have.property('bidfloor', 0.145);
+      const imp = data(buildRequest([bidRequest])).imp[0];
+      expect(imp).to.have.property('bidfloor', 0.145);
     });
 
-    it('should not add ext object with no ortb2imp injection', function () {
-      expect(ortbImps[0]).to.not.have.property('ext');
+    it('should map object from ortb2imp injection', () => {
+      expect(ortbImp).to.have.property('ext');
+      expect(ortbImp.ext).to.be.eql(bidRequest.ortb2Imp.ext);
     });
 
-    it('should map object from ortb2imp injection', function () {
-      expect(ortbImps[1]).to.have.property('ext');
-      expect(ortbImps[1].ext).to.be.eql(enriched_overlay_request.ortb2Imp.ext);
+    it('should not add ext object with no ortb2imp available', () => {
+      delete bidRequest.ortb2Imp;
+      ortbImp = data(buildRequest([bidRequest])).imp[0];
+      expect(ortbImp).to.not.have.property('ext');
     });
   });
 
-  describe('monetize request generation', function () {
+  describe('monetize request generation', () => {
     let monetizeRequest;
 
-    before(function () {
-      let requests = buildRequest([no_qxdata_has_apiurl_bid, enriched_overlay_request]);
-      monetizeRequest = requests[0].data;
+    beforeEach(() => {
+      monetizeRequest = data(buildRequest([bidRequest]));
     });
 
-    it('should have tmax', function () {
+    it('should have tmax', () => {
       expect(monetizeRequest.tmax).to.be.equal(3000);
     });
 
-    it('will not add qxData object if it does not exist', function () {
+    it('will not add qxData object if it does not exist', () => {
+      delete bidRequest.params.qxData;
+      monetizeRequest = data(buildRequest([bidRequest]));
       expect(monetizeRequest).to.not.have.property('qxData');
     });
 
-    it('will send qxData object when applicable', function () {
-      let overlay_mock = buildRequest([enriched_overlay_request]);
-      const enrichedRequest = overlay_mock[0].data;
-      expect(enrichedRequest.qxData).to.be.eql(sample_qxData);
+    it('will send qxData object when applicable', () => {
+      monetizeRequest = data(buildRequest([bidRequest]));
+      expect(monetizeRequest.qxData).to.be.eql(sample_qxData);
     });
 
-    it('will not add consent information if it does not exist', function () {
+    it('will not add consent information if it does not exist', () => {
       expect(monetizeRequest).to.not.have.property('GDPRApplies');
       expect(monetizeRequest).to.not.have.property('TCString');
       expect(monetizeRequest).to.not.have.property('USPString');
     });
 
-    it('should contain gdpr-related information if consent is configured', function () {
-      let requests = buildRequest([enriched_overlay_request],
-        buildBidderRequest('https://example.com/index.html',
+    it('will not add gdprApplies if unavailable', () => {
+      const request = buildRequest([bidRequest],
+        buildBidderRequest(exampleUrl,
+          {gdprConsent: {}, uspConsent: '1YNN'}));
+      monetizeRequest = data(request);
+      expect(monetizeRequest).to.not.have.property('GDPRApplies');
+    })
+
+    it('should contain gdpr-related information if consent is configured', () => {
+      const request = buildRequest([bidRequest],
+        buildBidderRequest(exampleUrl,
           {gdprConsent: {gdprApplies: true, consentString: 'tcStringValue', vendorData: {}}, uspConsent: '1YNN'}));
-      monetizeRequest = requests[0].data;
+      monetizeRequest = data(request);
       expect(monetizeRequest).to.have.property('GDPRApplies');
       expect(monetizeRequest.GDPRApplies).to.be.eql(1);
       expect(monetizeRequest).to.have.property('TCString');
@@ -396,57 +295,88 @@ describe('CatapultX adapter', function () {
       expect(monetizeRequest.USPString).to.be.eql('1YNN');
     });
 
-    it('should send 0 value for coppa when not true', function () {
+    it('should send 0 value for coppa when not true', () => {
       expect(monetizeRequest.coppa).to.be.eql(0);
     });
 
-    it('should contain coppa if configured', function () {
+    it('should contain coppa if configured', () => {
       config.setConfig({coppa: true});
-      let requests = buildRequest([no_qxdata_has_apiurl_bid]);
-      monetizeRequest = requests[0].data;
+      const request = buildRequest([bidRequest]);
+      monetizeRequest = data(request);
       expect(monetizeRequest).to.have.property('coppa');
       expect(monetizeRequest.coppa).to.be.eql(1);
     });
 
-    it('should only send configured values for consent information', function () {
-      let requests = buildRequest([enriched_overlay_request], buildBidderRequest('https://example.com/index.html', {gdprConsent: {gdprApplies: false}}));
-      monetizeRequest = requests[0].data;
+    it('should only send configured values for consent information', () => {
+      const request = buildRequest([bidRequest], buildBidderRequest(exampleUrl, {gdprConsent: {gdprApplies: false}}));
+      monetizeRequest = data(request);
       expect(monetizeRequest).to.have.property('GDPRApplies')
       expect(monetizeRequest.GDPRApplies).to.be.eql(0);
       expect(monetizeRequest).to.not.have.property('TCString');
       expect(monetizeRequest).to.not.have.property('USPString');
     });
 
-    it('should not include dnt if not applicable', function () {
-      let requests = buildRequest([enriched_overlay_request], DEFAULT_BIDDER_REQUEST, false);
-      expect(requests[0].data).to.not.have.property('dnt');
+    it('should include site.content if available', () => {
+      const request = buildRequest([bidRequest], buildBidderRequest(exampleUrl, { ortb2: ortb2Data }));
+      monetizeRequest = data(request);
+      expect(monetizeRequest.content).to.be.eql(ortb2Data.site.content);
+    })
+
+    it('should not include site.content if not available', () => {
+      expect(monetizeRequest).to.not.have.property('content');
+    })
+
+    it('should not include dnt if not applicable', () => {
+      const request = buildRequest([bidRequest], buildBidderRequest(), false);
+      expect(data(request)).to.not.have.property('dnt');
     });
 
-    it('should set dnt if applicable', function () {
+    it('should set dnt if applicable', () => {
       expect(monetizeRequest).to.have.property('dnt');
       expect(monetizeRequest.dnt).to.be.eql(1);
     });
   });
 
-  describe('interprets responses', function () {
-    it('should return empty array for no bid response in seatbid', function () {
-      let resp = spec.interpretResponse({body: no_seatbid_response});
+  describe('interprets responses', () => {
+    it('should return empty array for no bid response in seatbid', () => {
+      bidResponse.seatbid = []
+      const resp = spec.interpretResponse({body: bidResponse});
       expect(resp).to.be.eql([]);
     });
 
-    it('should return empty array for missing seatbid array', function () {
-      let resp = spec.interpretResponse({body: missing_seatbid_response});
+    it('should return empty array for missing seatbid array', () => {
+      delete bidResponse.seatbid 
+      const resp = spec.interpretResponse({body: bidResponse});
       expect(resp).to.be.eql([]);
     });
 
-    it('should default currency to USD when cur is missing from response', function () {
-      let resp = spec.interpretResponse({body: missing_cur_bid_response})[0];
+    it('should default currency to USD when cur is missing from response', () => {
+      delete bidResponse.cur;
+      const resp = spec.interpretResponse({body: bidResponse})[0];
       expect(resp).to.have.property('currency');
       expect(resp.currency).to.be.eql('USD');
     });
 
-    it('should interpret banner rtb response', function () {
-      let resp = spec.interpretResponse({body: bid_response})[0];
+    it('should not add invalid adomain', () => {
+      bidResponse.seatbid[0].bid[0].adomain = "string"
+      const resp = spec.interpretResponse({body: bidResponse})[0];
+      expect(resp?.meta?.advertiserDomains).to.be.undefined;
+    });
+
+    it('should not add empty cat array', () => {
+      bidResponse.seatbid[0].bid[0].cat = []
+      const resp = spec.interpretResponse({body: bidResponse})[0];
+      expect(resp?.meta?.primaryCatId).to.be.undefined;
+    });
+
+    it('should not add secondary category if array only contains one', () => {
+      bidResponse.seatbid[0].bid[0].cat = ['IAB1'];
+      const resp = spec.interpretResponse({body: bidResponse})[0];
+      expect(resp?.meta?.secondaryCatIds).to.be.undefined;
+    })
+
+    it('should interpret banner rtb response', () => {
+      const resp = spec.interpretResponse({body: bidResponse})[0];
       expect(resp).to.have.property('requestId', 'testBid3');
       expect(resp).to.have.property('cpm', 2);
       expect(resp).to.have.property('width', 728);


### PR DESCRIPTION
Hello!

This PR contains the finalized code for the catapultx bid adapter. I would like to submit this for review before I start the contribution process on the source Prebid.js repository. Below you will find the bidder code, the markdown file explaining implementation, and a testing suite that should cover all lines of logic in the main spec object of our adapter.

If you would like to test this with a local sandbox, please have gulp installed, install dependencies, and create a build using

`gulp build --modules=fpdModule,adpod,catapultxBidAdapter,consentManagement,consentManagementUsp,enrichmentFpdModule,gdprEnforcement,gptPreAuction,bidViewability,dfpAdServerVideo` as this is the build parameters we have been using on the local sandbox

The main points I would like to have discussed or understood before we move forward are:
- This currently only supports BANNER
- the bidder code and file names reflect catapultx at this time, please advise if we need to update the naming
- the default pipeline defaults the API url to dev, as we do not have the current monetize logic updated on production, should we release and point to production at this time?

Once this PR is approved and merged, I will consider it complete and will initiate a pull request to prebid source repository. Thank you for your review and your consideration, as well as your suppport throughout this process.