### PR TITLE
Qortex RTD Provider: new provider

### DIFF
--- a/modules/qortexRtdProvider.js
+++ b/modules/qortexRtdProvider.js
@@ -1,0 +1,165 @@
+import { submodule } from '../src/hook.js';
+import { ajax } from '../src/ajax.js';
+import { logWarn, mergeDeep, logMessage, generateUUID } from '../src/utils.js';
+import { loadExternalScript } from '../src/adloader.js';
+import * as events from '../src/events.js';
+import CONSTANTS from '../src/constants.json';
+
+let requestUrl;
+let bidderArray;
+let impressionIds;
+let currentSiteContext;
+
+/**
+ * Init if module configuration is valid
+ * @param {Object} config Module configuration
+ * @returns {Boolean}
+ */
+function init (config) {
+  if (!config?.params?.groupId?.length > 0) {
+    logWarn('Qortex RTD module config does not contain valid groupId parameter. Config params: ' + JSON.stringify(config.params))
+    return false;
+  } else {
+    initializeModuleData(config);
+  }
+  if (config?.params?.tagConfig) {
+    loadScriptTag(config)
+  }
+  return true;
+}
+
+/**
+ * Processess prebid request and attempts to add context to ort2b fragments
+ * @param {Object} reqBidsConfig Bid request configuration object
+ * @param {Function} callback Called on completion
+ */
+function getBidRequestData (reqBidsConfig, callback) {
+  if (reqBidsConfig?.adUnits?.length > 0) {
+    getContext()
+      .then(contextData => {
+        setContextData(contextData)
+        addContextToRequests(reqBidsConfig)
+        callback();
+      })
+      .catch((e) => {
+        logWarn(e?.message);
+        callback();
+      });
+  } else {
+    logWarn('No adunits found on request bids configuration: ' + JSON.stringify(reqBidsConfig))
+    callback();
+  }
+}
+
+/**
+ * determines whether to send a request to context api and does so if necessary
+ * @returns {Promise} ortb Content object
+ */
+export function getContext () {
+  if (!currentSiteContext) {
+    logMessage('Requesting new context data');
+    return new Promise((resolve, reject) => {
+      const callbacks = {
+        success(text, data) {
+          const result = data.status === 200 ? JSON.parse(data.response)?.content : null;
+          resolve(result);
+        },
+        error(error) {
+          reject(new Error(error));
+        }
+      }
+      ajax(requestUrl, callbacks)
+    })
+  } else {
+    logMessage('Adding Content object from existing context data');
+    return new Promise(resolve => resolve(currentSiteContext));
+  }
+}
+
+/**
+ * Updates bidder configs with the response from Qortex context services
+ * @param {Object} reqBidsConfig Bid request configuration object
+ * @param {string[]} bidders Bidders specified in module's configuration
+ */
+export function addContextToRequests (reqBidsConfig) {
+  if (currentSiteContext === null) {
+    logWarn('No context data recieved at this time');
+  } else {
+    const fragment = { site: {content: currentSiteContext} }
+    if (bidderArray?.length > 0) {
+      bidderArray.forEach(bidder => mergeDeep(reqBidsConfig.ortb2Fragments.bidder, {[bidder]: fragment}))
+    } else if (!bidderArray) {
+      mergeDeep(reqBidsConfig.ortb2Fragments.global, fragment);
+    } else {
+      logWarn('Config contains an empty bidders array, unable to determine which bids to enrich');
+    }
+  }
+}
+
+/**
+ * Loads Qortex header tag using data passed from module config object
+ * @param {Object} config module config obtained during init
+ */
+export function loadScriptTag(config) {
+  const code = 'qortex';
+  const groupId = config.params.groupId;
+  const src = 'https://tags.qortex.ai/bootstrapper'
+  const attr = {'data-group-id': groupId}
+  const tc = config.params.tagConfig
+
+  Object.keys(tc).forEach(p => {
+    attr[`data-${p.replace(/([A-Z])/g, (m) => `-${m.toLowerCase()}`)}`] = tc[p]
+  })
+
+  addEventListener('qortex-rtd', (e) => {
+    const billableEvent = {
+      vendor: code,
+      billingId: generateUUID(),
+      type: e?.detail?.type,
+      accountId: groupId
+    }
+    switch (e?.detail?.type) {
+      case 'qx-impression':
+        const {uid} = e.detail;
+        if (!uid || impressionIds.has(uid)) {
+          logWarn(`recieved invalid billable event due to ${!uid ? 'missing' : 'duplicate'} uid: qx-impression`)
+          return;
+        } else {
+          logMessage('recieved billable event: qx-impression')
+          impressionIds.add(uid)
+          billableEvent.transactionId = e.detail.uid;
+          events.emit(CONSTANTS.EVENTS.BILLABLE_EVENT, billableEvent);
+          break;
+        }
+      default:
+        logWarn(`recieved invalid billable event: ${e.detail?.type}`)
+    }
+  })
+
+  loadExternalScript(src, code, undefined, undefined, attr);
+}
+
+/**
+ * Helper function to set initial values when they are obtained by init
+ * @param {Object} config module config obtained during init
+ */
+export function initializeModuleData(config) {
+  const DEFAULT_API_URL = 'https://demand.qortex.ai';
+  const {apiUrl, groupId, bidders} = config.params;
+  requestUrl = `${apiUrl || DEFAULT_API_URL}/api/v1/analyze/${groupId}/prebid`;
+  bidderArray = bidders;
+  impressionIds = new Set();
+  currentSiteContext = null;
+}
+
+export function setContextData(value) {
+  currentSiteContext = value
+}
+
+export const qortexSubmodule = {
+  name: 'qortex',
+  init,
+  getBidRequestData
+}
+
+submodule('realTimeData', qortexSubmodule);

--- a/modules/qortexRtdProvider.md
+++ b/modules/qortexRtdProvider.md
@@ -1,0 +1,69 @@
+# Qortex Real-time Data Submodule
+
+## Overview
+
+```
+Module Name: Qortex RTD Provider
+Module Type: RTD Provider
+Maintainer: mannese@qortex.ai
+```
+
+## Description
+
+The Qortex RTD module appends contextual segments to the bidding object based on the content of a page using the Qortex API.
+
+Upon load, the Qortex context API will analyze the bidder page (video, text, image, etc.) and will return a [Content object](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf#page=26). The module will then merge that object into the appropriate bidders' `ortb2.site.content`, which can be used by prebid adapters that use `site.content` data.
+
+
+## Build
+```
+gulp build --modules="rtdModule,qortexRtdProvider,qortexBidAdapter,..."  
+```
+
+> `rtdModule` is a required module to use Qortex RTD module.
+
+## Configuration
+
+Please refer to [Prebid Documentation](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-realTimeData) on RTD module configuration for details on required and optional parameters of `realTimeData`
+
+When configuring Qortex as a data provider, refer to the template below to add the necessary information to ensure the proper connection is made.  
+
+### RTD Module Setup
+
+```javascript
+pbjs.setConfig({
+    realTimeData: {
+        auctionDelay: 1000,
+        dataProviders: [{
+            name: 'qortex',
+            waitForIt: true,
+            params: {
+                groupId: 'ABC123', //required
+                bidders: ['qortex', 'adapter2'], //optional (see below)
+                tagConfig: { // optional, please reach out to your account manager for configuration reccommendation
+                    videoContainer: 'string',
+                    htmlContainer: 'string',
+                    attachToTop: 'string',
+                    esm6Mod: 'string',
+                    continuousLoad: 'string'
+                }
+            }
+        }]
+    }
+});
+```
+
+### Paramter Details
+
+#### `groupId` - Required
+- The Qortex groupId linked to the publisher, this is required to make a request using this adapter
+
+#### `bidders` - optional
+- If this parameter is included, it must be an array of the strings that match the bidder code of the prebid adapters you would like this module to impact. `ortb2.site.content` will be updated *only* for adapters in this array
+
+- If this parameter is omitted, the RTD module will default to updating  `ortb2.site.content` on *all* bid adapters being used on the page
+
+#### `tagConfig` - optional
+- This optional parameter is an object containing the config settings that could be usedto initialize the Qortex integration on your page. A preconfigured object for this step will be provided to you by the Qortex team.
+
+- If this parameter is not present, the Qortex integration can still be configured and loaded manually on your page outside of prebid. The RTD module will continue to initialize and operate as normal.

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -27,6 +27,7 @@ const _approvedLoadExternalJSList = [
   'clean.io',
   'a1Media',
   'geoedge',
+  'qortex'
 ]
 
 /**

--- a/test/spec/modules/qortexRtdProvider_spec.js
+++ b/test/spec/modules/qortexRtdProvider_spec.js
@@ -1,0 +1,354 @@
+import * as utils from 'src/utils';
+import * as ajax from 'src/ajax.js';
+import * as events from 'src/events.js';
+import CONSTANTS from '../../../src/constants.json';
+import {loadExternalScript} from 'src/adloader.js';
+import {
+  qortexSubmodule as module,
+  getContext,
+  addContextToRequests,
+  setContextData,
+  initializeModuleData,
+  loadScriptTag
+} from '../../../modules/qortexRtdProvider';
+import { cloneDeep } from 'lodash';
+
+describe('qortexRtdProvider', () => {
+  let logWarnSpy;
+  let mockServer;
+  let ajaxSpy;
+  let ortb2Stub;
+
+  const defaultApiHost = 'https://demand.qortex.ai';
+  const defaultGroupId = 'test';
+  const validBidderArray = ['qortex', 'test'];
+  const validTagConfig = {
+    videoContainer: 'my-video-container'
+  }
+
+  const validModuleConfig = {
+    params: {
+      groupId: defaultGroupId,
+      apiUrl: defaultApiHost,
+      bidders: validBidderArray
+    }
+  };
+
+  const validImpressionEvent = {
+      detail: {
+        uid: 'uid123',
+        type: 'qx-impression'
+      }
+    },
+    validImpressionEvent2 = {
+      detail: {
+        uid: 'uid1234',
+        type: 'qx-impression'
+      }
+    },
+    missingIdImpressionEvent = {
+      detail: {
+        type: 'qx-impression'
+      }
+    },
+    invalidTypeQortexEvent = {
+      detail: {
+        type: 'invalid-type'
+      }
+    }
+
+  const emptyModuleConfig = {
+    params: {}
+  }
+
+  const responseHeaders = {
+    'content-type': 'application/json',
+    'access-control-allow-origin': '*'
+  };
+
+  const responseObj = {
+    content: {
+      id: '123456',
+      episode: 15,
+      title: 'test episode',
+      series: 'test show',
+      season: '1',
+      url: 'https://example.com/file.mp4'
+    }
+  };
+
+  const apiResponse = JSON.stringify(responseObj);
+
+  const reqBidsConfig = {
+    adUnits: [{
+      bids: [
+        { bidder: 'qortex' }
+      ]
+    }],
+    ortb2Fragments: {
+      bidder: {},
+      global: {}
+    }
+  }
+
+  beforeEach(() => {
+    mockServer = sinon.createFakeServer();
+    mockServer.respondWith([200, responseHeaders, apiResponse]);
+    mockServer.respondImmediately = true;
+    mockServer.autoRespond = true;
+
+    ortb2Stub = sinon.stub(reqBidsConfig, 'ortb2Fragments').value({bidder: {}, global: {}})
+    logWarnSpy = sinon.spy(utils, 'logWarn');
+    ajaxSpy = sinon.spy(ajax, 'ajax');
+  })
+
+  afterEach(() => {
+    ajaxSpy.restore();
+    logWarnSpy.restore();
+    ortb2Stub.restore();
+    mockServer.restore();
+    setContextData(null);
+  })
+
+  describe('init', () => {
+    it('returns true for valid config object', () => {
+      expect(module.init(validModuleConfig)).to.be.true;
+    })
+
+    it('returns false and logs error for missing groupId', () => {
+      expect(module.init(emptyModuleConfig)).to.be.false;
+      expect(logWarnSpy.calledOnce).to.be.true;
+      expect(logWarnSpy.calledWith('Qortex RTD module config does not contain valid groupId parameter. Config params: {}')).to.be.ok;
+    })
+
+    it('loads Qortex script if tagConfig is present in module config params', () => {
+      const config = cloneDeep(validModuleConfig);
+      config.params.tagConfig = validTagConfig;
+      expect(module.init(config)).to.be.true;
+      expect(loadExternalScript.calledOnce).to.be.true;
+    })
+  })
+
+  describe('loadScriptTag', () => {
+    let addEventListenerSpy;
+    let billableEvents = [];
+
+    let config = cloneDeep(validModuleConfig);
+    config.params.tagConfig = validTagConfig;
+
+    events.on(CONSTANTS.EVENTS.BILLABLE_EVENT, (e) => {
+      billableEvents.push(e);
+    })
+
+    beforeEach(() => {
+      initializeModuleData(config);
+      addEventListenerSpy = sinon.spy(window, 'addEventListener');
+    })
+
+    afterEach(() => {
+      addEventListenerSpy.restore();
+      billableEvents = [];
+    })
+
+    it('adds event listener', () => {
+      loadScriptTag(config);
+      expect(addEventListenerSpy.calledOnce).to.be.true;
+    })
+
+    it('parses incoming qortex-impression events', () => {
+      loadScriptTag(config);
+      dispatchEvent(new CustomEvent('qortex-rtd', validImpressionEvent));
+      expect(billableEvents.length).to.be.equal(1);
+      expect(billableEvents[0].type).to.be.equal(validImpressionEvent.detail.type);
+      expect(billableEvents[0].transactionId).to.be.equal(validImpressionEvent.detail.uid);
+    })
+
+    it('will emit two events for impressions with two different ids', () => {
+      loadScriptTag(config);
+      dispatchEvent(new CustomEvent('qortex-rtd', validImpressionEvent));
+      dispatchEvent(new CustomEvent('qortex-rtd', validImpressionEvent2));
+      expect(billableEvents.length).to.be.equal(2);
+      expect(billableEvents[0].transactionId).to.be.equal(validImpressionEvent.detail.uid);
+      expect(billableEvents[1].transactionId).to.be.equal(validImpressionEvent2.detail.uid);
+    })
+
+    it('will not allow multiple events with the same id', () => {
+      loadScriptTag(config);
+      dispatchEvent(new CustomEvent('qortex-rtd', validImpressionEvent));
+      dispatchEvent(new CustomEvent('qortex-rtd', validImpressionEvent));
+      expect(billableEvents.length).to.be.equal(1);
+      expect(logWarnSpy.calledWith('recieved invalid billable event due to duplicate uid: qx-impression')).to.be.ok;
+    })
+
+    it('will not allow events with missing uid', () => {
+      loadScriptTag(config);
+      dispatchEvent(new CustomEvent('qortex-rtd', missingIdImpressionEvent));
+      expect(billableEvents.length).to.be.equal(0);
+      expect(logWarnSpy.calledWith('recieved invalid billable event due to missing uid: qx-impression')).to.be.ok;
+    })
+
+    it('will not allow events with unavailable type', () => {
+      loadScriptTag(config);
+      dispatchEvent(new CustomEvent('qortex-rtd', invalidTypeQortexEvent));
+      expect(billableEvents.length).to.be.equal(0);
+      expect(logWarnSpy.calledWith('recieved invalid billable event: invalid-type')).to.be.ok;
+    })
+  })
+
+  describe('getBidRequestData', () => {
+    let callbackSpy;
+
+    beforeEach(() => {
+      initializeModuleData(validModuleConfig);
+      callbackSpy = sinon.spy();
+    })
+
+    afterEach(() => {
+      initializeModuleData(emptyModuleConfig);
+      callbackSpy.resetHistory();
+    })
+
+    it('will call callback immediately if no adunits', () => {
+      const reqBidsConfigNoBids = { adUnits: [] };
+      module.getBidRequestData(reqBidsConfigNoBids, callbackSpy);
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(logWarnSpy.calledWith('No adunits found on request bids configuration: ' + JSON.stringify(reqBidsConfigNoBids))).to.be.ok;
+    })
+
+    it('will call callback if getContext does not throw', (done) => {
+      module.getBidRequestData(reqBidsConfig, callbackSpy);
+      setTimeout(() => {
+        expect(ajaxSpy.calledOnce).to.be.true;
+        expect(callbackSpy.calledOnce).to.be.true;
+        done();
+      }, 100)
+    })
+
+    it('will catch and log error and fire callback', (done) => {
+      ajaxSpy.restore();
+      sinon.stub(ajax, 'ajax').throws(new Error('test error'))
+      module.getBidRequestData(reqBidsConfig, callbackSpy);
+      setTimeout(() => {
+        expect(callbackSpy.calledOnce).to.be.true;
+        expect(logWarnSpy.calledWith('test error')).to.be.ok;
+        done();
+      }, 100)
+    })
+  })
+
+  describe('getContext', () => {
+    beforeEach(() => {
+      initializeModuleData(validModuleConfig);
+    })
+
+    afterEach(() => {
+      initializeModuleData(emptyModuleConfig);
+    })
+
+    it('returns a promise', () => {
+      const result = getContext();
+      expect(result).to.be.a('promise');
+    })
+
+    it('uses request url generated from initialize function in config and resolves to content object data', (done) => {
+      let requestUrl = `${validModuleConfig.params.apiUrl}/api/v1/analyze/${validModuleConfig.params.groupId}/prebid`;
+      getContext().then(response => {
+        expect(response).to.be.eql(responseObj.content);
+        expect(ajaxSpy.calledOnce).to.be.true;
+        expect(ajaxSpy.calledWith(requestUrl)).to.be.true;
+
+        expect(response).to.be.eql(responseObj.content);
+
+        done();
+      });
+    })
+
+    it('will return existing context data instead of ajax call if the source was not updated', (done) => {
+      setContextData(responseObj.content);
+      getContext().then(response => {
+        expect(response).to.be.eql(responseObj.content);
+        expect(ajaxSpy.calledOnce).to.be.false;
+        done();
+      })
+    })
+
+    it('returns null for non erroring api responses other than 200', (done) => {
+      mockServer = sinon.createFakeServer();
+      mockServer.respondWith([204, {content: null}, '']);
+      mockServer.respondImmediately = true;
+      mockServer.autoRespond = true;
+      getContext().then(response => {
+        expect(response).to.be.null;
+        expect(ajaxSpy.calledOnce).to.be.true;
+        expect(logWarnSpy.called).to.be.false;
+        done();
+      });
+    })
+
+    it('returns a promise that rejects to an Error if ajax errors', () => {
+      mockServer = sinon.createFakeServer();
+      mockServer.respondWith([500, {}, '']);
+      mockServer.respondImmediately = true;
+      mockServer.autoRespond = true;
+      getContext().then().catch(err => {
+        expect(err).to.be.an('error');
+        done();
+      })
+    })
+  })
+
+  describe(' addContextToRequests', () => {
+    it('logs error if no data was retrieved from get context call', () => {
+      initializeModuleData(validModuleConfig);
+      addContextToRequests(reqBidsConfig);
+      expect(logWarnSpy.calledOnce).to.be.true;
+      expect(logWarnSpy.calledWith('No context data recieved at this time')).to.be.ok;
+      expect(reqBidsConfig.ortb2Fragments.global).to.be.eql({});
+      expect(reqBidsConfig.ortb2Fragments.bidder).to.be.eql({});
+    })
+
+    it('adds site.content only to global ortb2 when bidders array is omitted', () => {
+      const omittedBidderArrayConfig = cloneDeep(validModuleConfig);
+      delete omittedBidderArrayConfig.params.bidders;
+      initializeModuleData(omittedBidderArrayConfig);
+      setContextData(responseObj.content);
+      addContextToRequests(reqBidsConfig);
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.property('site');
+      expect(reqBidsConfig.ortb2Fragments.global.site).to.have.property('content');
+      expect(reqBidsConfig.ortb2Fragments.global.site.content).to.be.eql(responseObj.content);
+      expect(reqBidsConfig.ortb2Fragments.bidder).to.be.eql({});
+    })
+
+    it('adds site.content only to bidder ortb2 when bidders array is included', () => {
+      initializeModuleData(validModuleConfig);
+      setContextData(responseObj.content);
+      addContextToRequests(reqBidsConfig);
+
+      const qortexOrtb2Fragment = reqBidsConfig.ortb2Fragments.bidder['qortex']
+      expect(qortexOrtb2Fragment).to.not.be.null;
+      expect(qortexOrtb2Fragment).to.have.property('site');
+      expect(qortexOrtb2Fragment.site).to.have.property('content');
+      expect(qortexOrtb2Fragment.site.content).to.be.eql(responseObj.content);
+
+      const testOrtb2Fragment = reqBidsConfig.ortb2Fragments.bidder['test']
+      expect(testOrtb2Fragment).to.not.be.null;
+      expect(testOrtb2Fragment).to.have.property('site');
+      expect(testOrtb2Fragment.site).to.have.property('content');
+      expect(testOrtb2Fragment.site.content).to.be.eql(responseObj.content);
+
+      expect(reqBidsConfig.ortb2Fragments.global).to.be.eql({});
+    })
+
+    it('logs error if there is an empty bidder array', () => {
+      const invalidBidderArrayConfig = cloneDeep(validModuleConfig);
+      invalidBidderArrayConfig.params.bidders = [];
+      initializeModuleData(invalidBidderArrayConfig);
+      setContextData(responseObj.content)
+      addContextToRequests(reqBidsConfig);
+
+      expect(logWarnSpy.calledWith('Config contains an empty bidders array, unable to determine which bids to enrich')).to.be.ok;
+      expect(reqBidsConfig.ortb2Fragments.global).to.be.eql({});
+      expect(reqBidsConfig.ortb2Fragments.bidder).to.be.eql({});
+    })
+  })
+})


### PR DESCRIPTION
<!--

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
Adds new RTD module <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 

## Description of change
Creates new RTD adapter
- 100% line coverage

```
Module Name: Qortex RTD Provider
Module Type: RTD Provider
Maintainer: mannese@qortex.ai
```

```
realTimeData: {
                    auctionDelay: 1000,
                    dataProviders: [    
                        {
                            name: "qortex",
                            waitForIt: true,
                            params: {
                                groupId: 'banner',
                                videoContainer: 'my-video-container',
                                apiUrl: 'https://dev-demand.qortex.ai',
                                tagConfig: {
                                    videoContainer: 'my-video-container'
                                }
                            }

                        }
                    ]
                }
```


## Other information
@mickannese 
@rrochwick 
